### PR TITLE
Linkedin Auth

### DIFF
--- a/api/auth/auth.js
+++ b/api/auth/auth.js
@@ -4,6 +4,7 @@ let BasicStrategy           = require('passport-http').BasicStrategy;
 let ClientPasswordStrategy  = require('passport-oauth2-client-password').Strategy;
 let BearerStrategy          = require('passport-http-bearer').Strategy;
 let GoogleStrategy          = require('passport-google-oauth2').Strategy;
+let LinkedinStrategy        = require('@sokratis/passport-linkedin-oauth2').Strategy;
 let User                    = require('../../models/user');
 let ClientModel             = require('../../models/tokenModels').ClientModel;
 let AccessTokenModel        = require('../../models/tokenModels').AccessTokenModel;
@@ -139,3 +140,23 @@ passport.use(new GoogleStrategy({
         });
     }
 ));
+
+// Linkedin auth strategy
+passport.use(new LinkedinStrategy({
+  clientID: process.env.LINKEDIN_CLIENT_ID,
+  clientSecret: process.env.LINKEDIN_CLIENT_SECRET,
+  callbackURL: process.env.LINKEDIN_REDIRECT_URI,
+  scope: ['r_emailaddress', 'r_liteprofile', 'r_fullprofile']
+}, function(accessToken, refreshToken, profile, done) {
+  // asynchronous verification, for effect...
+  console.log('here2')
+  console.log(accessToken);
+  console.log(refreshToken)
+  // process.nextTick(function () {
+    // To keep the example simple, the user's LinkedIn profile is returned to
+    // represent the logged-in user. In a typical application, you would want
+    // to associate the LinkedIn account with a user record in your database,
+    // and return that user instead.
+    return done(null, profile);
+  // });
+})); 

--- a/app.js
+++ b/app.js
@@ -83,6 +83,7 @@ app.post('/locale/exchange', (req, res, next) => {
 
 });
 
+// Locale OAuth
 app.use('/locale', oauth2.token);
 
 // Google OAuth
@@ -95,6 +96,17 @@ app.get('/google/callback', passport.authenticate('google'), function(req, res, 
   .then((user) => {
       return res.redirect('/redirect?token='+user.temporaryToken.value+( (req.query.state && req.query.state !== '{}') ? '&state='+req.query.state : ''));
   });
+});
+
+// Linkedin OAuth
+app.get('/linkedin', (req, res, next) => {
+  console.log('here')
+  return passport.authenticate('linkedin', { scope: ['r_liteprofile', 'r_emailaddress', 'r_fullprofile'] , state: req.query.state})(req, res, next);
+});
+
+app.get('/linkedin/callback', passport.authenticate('linkedin'), function(req, res, next){
+  console.log('ok')
+  return res.status(200).json({user: req.user});
 });
 
 // Register

--- a/models/linkedinUser.js
+++ b/models/linkedinUser.js
@@ -1,0 +1,18 @@
+let mongoose = require('mongoose');
+
+var LinkedinUserSchema = mongoose.Schema({
+  user: {type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true},
+  accessToken: {type: mongoose.Schema.Types.ObjectId, ref: 'AccessToken'},
+  refreshToken: {type: mongoose.Schema.Types.ObjectId, ref: 'RefreshToken', required: true},
+  created: { type: Date, default: Date.now },
+  updated: { type: Date, default: Date.now }
+});
+
+LinkedinUserSchema.pre('save', function(next) {
+  this.updated = Date.now();
+  return next();
+});
+
+var LinkedinUser = mongoose.model('LinkedinUser', LinkedinUserSchema);
+
+module.exports = LinkedinUser;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://wingzy.com",
   "dependencies": {
+    "@sokratis/passport-linkedin-oauth2": "^2.0.2",
     "apidoc": "^0.17.7",
     "connect-mongo": "^1.3.2",
     "crypto": "^1.0.1",


### PR DESCRIPTION
## STATE
Work in progress

## DESCRIPTION 
- Add LinkedIn strategy to passport strategy available
- Create LinkeinUser object to store linkedin data

## TODO
- [x] Create LinkedinUser object
- [ ] Add methods & properties to object model
- [ ] 1st version : profile lite data + email
- [ ] Think about 2nd version : more data like talents, people linked, etc.
- [x] Add passport strategy
- [ ] Implements passport strategy with LinkedinUser object findOrCreate
- [ ] Add linkedin auth routes + callback

## INFO
https://github.com/auth0/passport-linkedin-oauth2/pull/69
